### PR TITLE
allow providing plural translations as array in translation file

### DIFF
--- a/src/Translate.php
+++ b/src/Translate.php
@@ -326,9 +326,11 @@ class Translate
      */
     public function plural($string, $x, $args = null)
     {
-        $string = $this->getMessage($this->language, $string);
-
-        $choices = explode('|', $string);
+        $string  = $this->getMessage($this->language, $string);
+        $choices = $string;
+        if (false === is_array($string)) {
+            $choices = explode('|', $string);
+        }
         $args = isset($args) ? $args : array($x);
         if (isset($args)) {
             if (!is_array($args)) {


### PR DESCRIPTION
after merging this, one is able to define the plural translation as an array.
after merging this, one is able to have the delimiter as part of the translation in plural cases.
this pull request does not break bc. 

thx :)