### PR TITLE
translate fails for plural defined translations

### DIFF
--- a/src/Translate.php
+++ b/src/Translate.php
@@ -303,6 +303,9 @@ class Translate
     public function t($string, $args = null)
     {
         $string = $this->getMessage($this->language, $string);
+        if (true === is_array($string)) {
+            return $this->plural($string, 1, $args);
+        }
         if (isset($args)) {
             if (!is_array($args)) {
                 $args = func_get_args();

--- a/src/Translate.php
+++ b/src/Translate.php
@@ -302,9 +302,10 @@ class Translate
      */
     public function t($string, $args = null)
     {
-        $string = $this->getMessage($this->language, $string);
+        $original = $string;
+        $string   = $this->getMessage($this->language, $string);
         if (true === is_array($string)) {
-            return $this->plural($string, 1, $args);
+            return $this->plural($original, 1, $args);
         }
         if (isset($args)) {
             if (!is_array($args)) {
@@ -313,6 +314,7 @@ class Translate
             }
             $string = vsprintf($string, $args);
         }
+
         return $string;
     }
     


### PR DESCRIPTION
use plural translation if translate was called instead of plural function but plural is defined in translation map.
the translator now checks if the found translation is an array and then uses the plural translation. 